### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [https://message.land](message.land)
 
-Cabal-powered online chat! [http://cabal.chat](cabal.chat)
+Cabal-powered online chat! [http://cabal.chat](http://cabal.chat)


### PR DESCRIPTION
Without the protocol, the link is assumed to be relative to the current URL